### PR TITLE
Issue 5 allow endpoint url to be supplied

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.1025</version>
+                <version>1.12.99</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/com/github/jcustenborder/kafka/config/aws/SecretsManagerConfigProviderConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/config/aws/SecretsManagerConfigProviderConfig.java
@@ -44,10 +44,14 @@ class SecretsManagerConfigProviderConfig extends AbstractConfig {
   public static final String AWS_SECRET_KEY_CONFIG = "aws.secret.key";
   public static final String AWS_SECRET_KEY_DOC = "AWS secret access key to connect with.";
 
+  public static final String AWS_ENDPOINT_URL_CONFIG = "aws.endpoint.url";
+  public static final String AWS_ENDPOINT_URL_DOC = "Endpoint at which to hit aws. Most useful for localstack. Ex: localhost:4566";
+
   public final String region;
   public final long minimumSecretTTL;
   public final AWSCredentials credentials;
   public final String prefix;
+  public final String endpointUrl;
 
   public SecretsManagerConfigProviderConfig(Map<String, ?> settings) {
     super(config(), settings);
@@ -63,6 +67,7 @@ class SecretsManagerConfigProviderConfig extends AbstractConfig {
       credentials = null;
     }
     prefix = getString(PREFIX_CONFIG);
+    endpointUrl = getString(AWS_ENDPOINT_URL_CONFIG);
   }
 
   public static ConfigDef config() {
@@ -98,6 +103,12 @@ class SecretsManagerConfigProviderConfig extends AbstractConfig {
                 .importance(ConfigDef.Importance.LOW)
                 .defaultValue(Duration.ofMinutes(5L).toMillis())
                 .validator(ConfigDef.Range.atLeast(1000L))
+                .build()
+        ).define(
+            ConfigKeyBuilder.of(AWS_ENDPOINT_URL_CONFIG, ConfigDef.Type.STRING)
+                .documentation(AWS_ENDPOINT_URL_DOC)
+                .importance(ConfigDef.Importance.LOW)
+                .defaultValue(null)
                 .build()
         );
   }

--- a/src/main/java/com/github/jcustenborder/kafka/config/aws/SecretsManagerConfigProviderConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/config/aws/SecretsManagerConfigProviderConfig.java
@@ -45,7 +45,7 @@ class SecretsManagerConfigProviderConfig extends AbstractConfig {
   public static final String AWS_SECRET_KEY_DOC = "AWS secret access key to connect with.";
 
   public static final String AWS_ENDPOINT_URL_CONFIG = "aws.endpoint.url";
-  public static final String AWS_ENDPOINT_URL_DOC = "Endpoint at which to hit aws. Most useful for localstack. Ex: localhost:4566";
+  public static final String AWS_ENDPOINT_URL_DOC = "Endpoint at which to hit aws. Most useful for localstack. To use this config, aws.region MUST also be provided. Ex: http://localhost:4566";
 
   public final String region;
   public final long minimumSecretTTL;

--- a/src/main/java/com/github/jcustenborder/kafka/config/aws/SecretsManagerFactoryImpl.java
+++ b/src/main/java/com/github/jcustenborder/kafka/config/aws/SecretsManagerFactoryImpl.java
@@ -16,6 +16,7 @@
 package com.github.jcustenborder.kafka.config.aws;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
 
@@ -29,6 +30,10 @@ class SecretsManagerFactoryImpl implements SecretsManagerFactory {
     }
     if (null != config.credentials) {
       builder = builder.withCredentials(new AWSStaticCredentialsProvider(config.credentials));
+    }
+
+    if (null != config.endpointUrl) {
+      builder = builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(config.endpointUrl, null));
     }
 
     return builder.build();

--- a/src/main/java/com/github/jcustenborder/kafka/config/aws/SecretsManagerFactoryImpl.java
+++ b/src/main/java/com/github/jcustenborder/kafka/config/aws/SecretsManagerFactoryImpl.java
@@ -26,14 +26,15 @@ class SecretsManagerFactoryImpl implements SecretsManagerFactory {
     AWSSecretsManagerClientBuilder builder = AWSSecretsManagerClientBuilder.standard();
 
     if (null != config.region && !config.region.isEmpty()) {
-      builder = builder.withRegion(config.region);
-    }
-    if (null != config.credentials) {
-      builder = builder.withCredentials(new AWSStaticCredentialsProvider(config.credentials));
+      if (null != config.endpointUrl) {
+        builder = builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(config.endpointUrl, config.region));
+      } else {
+        builder = builder.withRegion(config.region);
+      }
     }
 
-    if (null != config.endpointUrl) {
-      builder = builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(config.endpointUrl, null));
+    if (null != config.credentials) {
+      builder = builder.withCredentials(new AWSStaticCredentialsProvider(config.credentials));
     }
 
     return builder.build();

--- a/src/test/java/com/github/jcustenborder/kafka/config/aws/SecretsManagerConfigProviderConfigTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/config/aws/SecretsManagerConfigProviderConfigTest.java
@@ -1,0 +1,25 @@
+package com.github.jcustenborder.kafka.config.aws;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static com.github.jcustenborder.kafka.config.aws.SecretsManagerConfigProviderConfig.AWS_ENDPOINT_URL_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class SecretsManagerConfigProviderConfigTest {
+    @Test
+    public void noProvidedEndpointSetting() {
+        SecretsManagerConfigProviderConfig config = new SecretsManagerConfigProviderConfig(Collections.emptyMap());
+        assertNull(config.endpointUrl);
+    }
+
+    @Test
+    public void endpointSupplied() {
+        String endpoint = "localhost:4566";
+
+        SecretsManagerConfigProviderConfig config = new SecretsManagerConfigProviderConfig(Collections.singletonMap(AWS_ENDPOINT_URL_CONFIG, endpoint));
+        assertEquals(endpoint, config.endpointUrl);
+    }
+}


### PR DESCRIPTION
fixes 5. It will be beneficial to provide these override options so people can comprehensively test a kafka-connect stack which incorporates this plugin locally via localstack. 

Additional testing: In a full local kafka-connect environment with localstack I was able to confirm this plugin got secrets from localstack secretsmanager successfully.