### PR TITLE
include aws sdk sts lib to support web identity in default security chain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,10 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-secretsmanager</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Added STS dependency to pom. Tested this out within EKS cluster, which now correctly picks up the defined ENV variables:
AWS_WEB_IDENTITY_TOKEN_FILE=<token file>
AWS_ROLE_ARN=<arn>

